### PR TITLE
Removed platform and app type components, switch to docs api

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -145,18 +145,27 @@
   <script src="/build/build.js"></script>
   <script>
     ;(function() {
-      var TutorialNavigator = require('tutorial-navigator');
-      var tutorial = new TutorialNavigator();
-      tutorial.render('section.content');
-      // That's it!
+      $.getJSON('https://auth0.com/docs/meta/quickstart', function(data) {
+        var TutorialNavigator = require('tutorial-navigator');
+        var tutorial = new TutorialNavigator({
+          apptypes: data.app_types,
+          clientplatforms: data.client_platforms,
+          hybridplatforms: data.hybrid_platforms,
+          nativeplatforms: data.native_platforms,
+          serverplatforms: data.server_platforms,
+          serverapis: data.server_apis
+        });
+        tutorial.render('section.content');
+        // That's it!
 
-      // !!!: bonus track
-      // if provided with a function,
-      // this will be called right after
-      // the tutorial fetch ends and
-      // gets interted in dom
-      tutorial.pretty(function(el) {
-        return 'function' === typeof window.prettyPrint ? prettyPrint() : null;
+        // !!!: bonus track
+        // if provided with a function,
+        // this will be called right after
+        // the tutorial fetch ends and
+        // gets interted in dom
+        tutorial.pretty(function(el) {
+          return 'function' === typeof window.prettyPrint ? prettyPrint() : null;
+        });
       });
     })()
   </script>

--- a/example/routing.html
+++ b/example/routing.html
@@ -168,13 +168,23 @@
   </script>
   <script src="/build/build.js"></script>
   <script>
+
+  $.getJSON('https://auth0.com/docs/meta/quickstart', function(data) {
+
     /**
      * Tutorial Navigator routing example code
      * Note: 'Changes will be made to make this
      * code simpler...'
      */
     var TutorialNavigator = require('tutorial-navigator');
-    var tutorial = new TutorialNavigator();
+    var tutorial = new TutorialNavigator({
+      apptypes: data.app_types,
+      clientplatforms: data.client_platforms,
+      hybridplatforms: data.hybrid_platforms,
+      nativeplatforms: data.native_platforms,
+      serverplatforms: data.server_platforms,
+      serverapis: data.server_apis
+    });
     var eqlPath = function(url) {
       var base = page.base() || '';
       var path = window.location.pathname.slice(base.length) || '/';
@@ -305,5 +315,7 @@
     tutorial.pretty(function() {
       window.prettyPrint && window.prettyPrint();
     });
+
+  });
   </script>
 </html>

--- a/example/standalone.html
+++ b/example/standalone.html
@@ -15,8 +15,17 @@
   <div id="tutorial-container"></div>
   <script type="text/javascript">
     var TutorialNavigator = require('tutorial-navigator');
-    var tutorial = new TutorialNavigator();
-    tutorial.render('#tutorial-container');
+    $.getJSON('https://auth0.com/docs/meta/quickstart', function(data) {
+      var tutorial = new TutorialNavigator({
+        apptypes: data.app_types,
+        clientplatforms: data.client_platforms,
+        hybridplatforms: data.hybrid_platforms,
+        nativeplatforms: data.native_platforms,
+        serverplatforms: data.server_platforms,
+        serverapis: data.server_apis
+      });
+      tutorial.render('#tutorial-container');
+    }):
   </script>
 </body>
 </html>

--- a/lib/tutorial-model/component.json
+++ b/lib/tutorial-model/component.json
@@ -4,12 +4,7 @@
   "dependencies": {
     "component/to-function": "*",
     "modella/modella": "0.2.8",
-    "modella/defaults": "*",
-    "auth0/application-types": "0.1.1",
-    "auth0/client-platforms": "*",
-    "auth0/native-platforms": "*",
-    "auth0/server-platforms": "*",
-    "auth0/server-apis": "*"
+    "modella/defaults": "*"
   },
   "local": [ ],
   "scripts": [ "index.js" ],

--- a/lib/tutorial-model/index.js
+++ b/lib/tutorial-model/index.js
@@ -5,13 +5,6 @@
 var _ = require('to-function');
 var modella = require('modella');
 var defaults = require('modella-defaults');
-var apptypes = require('application-types');
-var nativeplatforms = require('native-platforms');
-var hybridplatforms = nativeplatforms.filter(_('hybrid'));
-var clientplatforms = require('client-platforms');
-var serverplatforms = require('server-platforms');
-var serverapis = require('server-apis');
-
 /**
  * Define model
  */
@@ -37,12 +30,12 @@ Tutorial
   .attr('clientPlatform', { default: '' })
   .attr('serverApi', { default: '' })
   .attr('serverPlatform', { default: '' })
-  .attr('apptypes', { default: apptypes })
-  .attr('nativeplatforms', { default: nativeplatforms })
-  .attr('hybridplatforms', { default: hybridplatforms })
-  .attr('clientplatforms', { default: clientplatforms })
-  .attr('serverplatforms', { default: serverplatforms })
-  .attr('serverapis', { default: serverapis })
+  .attr('apptypes', { default: [] })
+  .attr('nativeplatforms', { default: [] })
+  .attr('hybridplatforms', { default: [] })
+  .attr('clientplatforms', { default: [] })
+  .attr('serverplatforms', { default: [] })
+  .attr('serverapis', { default: [] })
   .attr('codevisible', { default: false })
   .attr('nativevisible', { default: false })
   .attr('hybridvisible', { default: false })


### PR DESCRIPTION
Now the tutorial navigator will exclusively use the docs api so that it will always be up to date with the latest content.