### PR TITLE
Added header with title and description to tutorial TOC sidebar

### DIFF
--- a/css/tutorial-navigator.styl
+++ b/css/tutorial-navigator.styl
@@ -286,6 +286,14 @@
   ul, li
     margin 0
     padding 0
+  .tutorial-toc-title
+    font-size 24px
+    color color_text_light
+  .tutorial-toc-description
+    font-size 12px
+    line-height 18px
+    color color_text_light
+    margin 10px 0 20px
   .tutorial-toc-article
     cursor pointer
     list-style none

--- a/src/components/tutorial-table-of-contents.jsx
+++ b/src/components/tutorial-table-of-contents.jsx
@@ -32,9 +32,13 @@ class TutorialTableOfContents extends React.Component {
         {article.title}
       </li>
     });
-    
+
     return (
       <div className="tutorial-toc">
+        <div className="tutorial-toc-header">
+          <div className="tutorial-toc-title">{platform.title} Tutorials</div>
+          <div className="tutorial-toc-description">{platform.description}</div>
+        </div>
         <ul className="tutorial-toc-articles">
           {items}
         </ul>


### PR DESCRIPTION
This patch adds a header with the platform name and description to the table of contents that is displayed when a platform has multiple tutorial articles defined.