### PR TITLE
Added microdata to Breadcrumbs

### DIFF
--- a/css/tutorial-navigator.styl
+++ b/css/tutorial-navigator.styl
@@ -254,6 +254,9 @@
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
   cursor: pointer;
 
+  > div
+    display: inline-block;
+    
   i
     font-size: 12px;
     animation: none;

--- a/src/components/breadcrumbs.jsx
+++ b/src/components/breadcrumbs.jsx
@@ -18,6 +18,7 @@ class Breadcrumbs extends React.Component {
   render() {
     let crumbs = [];
     let {quickstart, platform, article, isRestricted} = this.props;
+    let index = 1;
     
     if (!quickstart) {
       return <div />;
@@ -28,40 +29,63 @@ class Breadcrumbs extends React.Component {
     // top-level Documentation link.
     if (isRestricted) {
       crumbs.push(
-        <a key="quickstart" onClick={this.handleClick.bind(this, {quickstart})}>
-          <span className="text">{quickstart.title}</span>
-        </a>
+        <div itemProp="itemListElement" itemScope itemType="http://schema.org/ListItem">
+          <a itemProp="item" key="quickstart" onClick={this.handleClick.bind(this, {quickstart})}>
+            <span className="text" itemProp="name">{quickstart.title}</span>
+            <meta itemProp="position" content={index} />
+          </a>
+        </div>
       );
+      index++;
     }
     else {
       crumbs.push(
-        <a key="base" onClick={this.handleClick.bind(this, {})}>
-          <span className="text">Documentation</span>
-        </a>
+        <div itemProp="itemListElement" itemScope itemType="http://schema.org/ListItem">
+          <a itemProp="item" key="base" onClick={this.handleClick.bind(this, {})}>
+            <span className="text" itemProp="name">Documentation</span>
+            <meta itemProp="position" content={index} />
+          </a>
+        </div>
       );
+      index++;
+      crumbs.push(<i className="icon-budicon-461"></i>);
       crumbs.push(
-        <a key="quickstart" onClick={this.handleClick.bind(this, {quickstart})}>
-          <i className="icon-budicon-461"></i><span className="text">{quickstart.title}</span>
-        </a>
+        <div itemProp="itemListElement" itemScope itemType="http://schema.org/ListItem">
+          <a itemProp="item" key="quickstart" onClick={this.handleClick.bind(this, {quickstart})}>
+            <span className="text" itemProp="name">{quickstart.title}</span>
+            <meta itemProp="position" content={index} />
+          </a>
+        </div>
       );
+      index++;
     }
     
     if (platform) {
+      crumbs.push(<i className="icon-budicon-461"></i>);
       crumbs.push(
-        <a key="platform" onClick={this.handleClick.bind(this, {quickstart, platform})}>
-          <i className="icon-budicon-461"></i><span className="text">{platform.title}</span>
-        </a>
-      );
-      if (article && platform.articles.length > 1) {
-        crumbs.push(
-          <a key="article" onClick={this.handleClick.bind(this, {quickstart, platform, article})}>
-            <i className="icon-budicon-461"></i><span className="text">{article.title}</span>
+        <div itemProp="itemListElement" itemScope itemType="http://schema.org/ListItem">
+          <a itemProp="item" key="platform" onClick={this.handleClick.bind(this, {quickstart, platform})}>
+            <span className="text" itemProp="name">{platform.title}</span>
+            <meta itemProp="position" content={index} />
           </a>
+        </div>
+      );
+      index++;
+      if (article && platform.articles.length > 1) {
+        crumbs.push(<i className="icon-budicon-461"></i>);
+        crumbs.push(
+          <div itemProp="itemListElement" itemScope itemType="http://schema.org/ListItem">
+            <a itemProp="item" key="article" onClick={this.handleClick.bind(this, {quickstart, platform, article})}>
+              <span className="text" itemProp="name">{article.title}</span>
+              <meta itemProp="position" content={index} />
+            </a>
+          </div>
         );
+        index++;
       }
     }
     
-    return <div className="breadcrumbs">{crumbs}</div>;
+    return <div className="breadcrumbs" itemScope itemType="http://schema.org/BreadcrumbList">{crumbs}</div>;
   }
   
 }


### PR DESCRIPTION
SEO improvement for displaying rich snippets on Google Search Results.
Breadcrumbs on search results can increase click through rate. More over about breadcrumbs in Google on: https://developers.google.com/search/docs/data-types/breadcrumbs

New HTML attributes have been added following schema.org implementation guidelines. 
The two itemtypes that were added are:
- Itemtype -> http://schema.org/BreadcrumbList
- Itemtype -> http://schema.org/ListItem

Breadcrumb implementation can be tested using Google Structured Data Testing Tool -> https://search.google.com/structured-data/testing-tool