### PR TITLE
Fix for error where TutorialPrevNext incorrectly tried to show a next link where none existed

### DIFF
--- a/src/components/tutorial-prev-next.jsx
+++ b/src/components/tutorial-prev-next.jsx
@@ -36,7 +36,7 @@ class TutorialPrevNext extends React.Component {
           <i className="icon-budicon-463" />{prevArticle.title}
         </a>;
       }
-      if (platform.articles.length > 1 && currentIndex < platform.articles.length) {
+      if (platform.articles.length > 1 && currentIndex < platform.articles.length - 1) {
         let nextArticle = platform.articles[currentIndex + 1];
         next = <a className="tutorial-prevnext-next" onClick={this.handleClick.bind(this, nextArticle)}>
           {nextArticle.title} <i className="icon-budicon-461" />


### PR DESCRIPTION
This patch should fix the issue we currently see in production, where the last article will not render correctly.