### PR TITLE
Title and style tweaks

### DIFF
--- a/css/tutorial-navigator.styl
+++ b/css/tutorial-navigator.styl
@@ -29,7 +29,7 @@
     margin: 0;
     transition: min-height 100ms ease;
     color: #333;
-    padding: 40px 0;
+    padding: 0 0 40px;
 
     i
       font-size: inherit;

--- a/src/components/tutorial-navigator.jsx
+++ b/src/components/tutorial-navigator.jsx
@@ -9,7 +9,7 @@ class TutorialNavigator extends React.Component {
   
   render() {
     
-    let {quickstarts, quickstart} = this.props;
+    let {quickstarts, quickstart, firstQuestion} = this.props;
 
     let picker = undefined;
     let question = undefined;
@@ -22,7 +22,7 @@ class TutorialNavigator extends React.Component {
     }
     else {
       picker = <QuickstartList quickstarts={quickstarts} {...this.props} />;
-      question = "Getting started? Try our quickstarts."
+      question = firstQuestion;
     }
     
     return (
@@ -30,7 +30,6 @@ class TutorialNavigator extends React.Component {
         <div className='js-tutorial-navigator'>
           <div className="banner tutorial-wizard">
             <div className="container">
-              <h1>Documentation</h1>
               <p className='question-text'>{question}</p><br/>
               {breadcrumbs}
             </div>
@@ -43,9 +42,14 @@ class TutorialNavigator extends React.Component {
   
 }
 
+TutorialNavigator.defaultProps = {
+  firstQuestion: "Choose your application type"
+};
+
 TutorialNavigator.propTypes = {
   quickstarts: React.PropTypes.object,
-  quickstart: React.PropTypes.object
+  quickstart: React.PropTypes.object,
+  firstQuestion: React.PropTypes.string,
 }
 
 TutorialNavigator = connectToStores(TutorialNavigator, [TutorialStore], (context, props) => {


### PR DESCRIPTION
Related to https://github.com/auth0/auth0-docs/pull/1035

This removes the "Documentation" `<h1>` that was in here and moves it to the host site. This was necessary to allow the header to be moved above the `NavigationBar` on the quickstart selection page. Also, I added a new prop to the `TutorialNavigator` to allow configuration of the question the user is prompted with before they select an app type.