### PR TITLE
Added singleArticleMode flag

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -175,6 +175,9 @@ ExampleArticleService.loadArticle = function(quickstarts, payload) {
   
 };
 
+// Access the example at http://localhost:8990/?single to activate single-article mode.
+var singleArticleMode = document.location.search.indexOf('single') != -1;
+
 var context = TutorialNavigator.createCustomContext(ExampleArticleService);
 TutorialNavigator.loadSettingsAction(context, {quickstarts: EXAMPLE_QUICKSTART_DATA}, function(){})
-TutorialNavigator.renderElement(document.getElementById('app'), {context: context});
+TutorialNavigator.renderElement(document.getElementById('app'), {context, singleArticleMode});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-tutorial-navigator",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "private": true,
   "main": "index.js",
   "description": "Auth0's quickstarts",

--- a/src/action/load-article-action.js
+++ b/src/action/load-article-action.js
@@ -5,10 +5,17 @@ export default function loadArticleAction(context, payload, done) {
 
   let articleService = context.getService(ServiceKeys.ArticleService);
   let quickstarts = context.getStore(TutorialStore).getQuickstarts();
-  let {quickstartId, platformId, articleId, clientId} = payload;
+  let {quickstartId, platformId, articleId, clientId, singleArticleMode} = payload;
 
   if (quickstartId && platformId && !articleId) {
-    articleId = quickstarts[quickstartId].platforms[platformId].articles[0].name;
+    let platform = quickstarts[quickstartId].platforms[platformId];
+    if (singleArticleMode) {
+      let article = _.find(platform.articles, (a) => a.default);
+      if (article) articleId = article.name;
+    }
+    if (!articleId) {
+      articleId = platform.articles[0].name;
+    }
   }
 
   return articleService.loadArticle(quickstarts, {quickstartId, platformId, articleId, clientId})

--- a/src/components/platform-list.jsx
+++ b/src/components/platform-list.jsx
@@ -4,7 +4,7 @@ import Platform from './platform';
 class PlatformList extends React.Component {
   
   render() {
-    let {quickstart, customNavigationAction} = this.props;
+    let {quickstart, singleArticleMode, customNavigationAction} = this.props;
     
     let items = Object.keys(quickstart.platforms).map((name, i) => (
       <Platform
@@ -12,6 +12,7 @@ class PlatformList extends React.Component {
         delay={20 * i}
         quickstart={quickstart}
         platform={quickstart.platforms[name]}
+        singleArticleMode={singleArticleMode}
         customNavigationAction={customNavigationAction} />
     ));
 

--- a/src/components/platform.jsx
+++ b/src/components/platform.jsx
@@ -5,10 +5,11 @@ import loadArticleAction from '../action/load-article-action';
 class Platform extends React.Component {
   
   handleClick() {
-    let {quickstart, platform, customNavigationAction} = this.props;
+    let {quickstart, platform, singleArticleMode, customNavigationAction} = this.props;
     let payload = {
       quickstartId: quickstart.name,
-      platformId: platform.name
+      platformId: platform.name,
+      singleArticleMode
     };
     if (customNavigationAction) {
       this.context.executeAction(customNavigationAction, payload);
@@ -49,6 +50,7 @@ class Platform extends React.Component {
 Platform.propTypes = {
   quickstart: React.PropTypes.object,
   platform: React.PropTypes.object,
+  singleArticleMode: React.PropTypes.bool,
   customNavigationAction: React.PropTypes.func
 }
 

--- a/src/components/tutorial-navigator.jsx
+++ b/src/components/tutorial-navigator.jsx
@@ -9,7 +9,7 @@ class TutorialNavigator extends React.Component {
   
   render() {
     
-    let {quickstarts, quickstart, firstQuestion} = this.props;
+    let {quickstart, firstQuestion} = this.props;
 
     let picker = undefined;
     let question = undefined;
@@ -21,7 +21,7 @@ class TutorialNavigator extends React.Component {
       breadcrumbs = <Breadcrumbs {...this.props} />;
     }
     else {
-      picker = <QuickstartList quickstarts={quickstarts} {...this.props} />;
+      picker = <QuickstartList {...this.props} />;
       question = firstQuestion;
     }
     
@@ -50,6 +50,7 @@ TutorialNavigator.propTypes = {
   quickstarts: React.PropTypes.object,
   quickstart: React.PropTypes.object,
   firstQuestion: React.PropTypes.string,
+  singleArticleMode: React.PropTypes.bool
 }
 
 TutorialNavigator = connectToStores(TutorialNavigator, [TutorialStore], (context, props) => {

--- a/src/view/navigator-and-tutorial-view.jsx
+++ b/src/view/navigator-and-tutorial-view.jsx
@@ -22,12 +22,17 @@ NavigatorAndTutorialView.propTypes = {
   platform: React.PropTypes.object,
   article: React.PropTypes.object,
   restrict: React.PropTypes.string,
+  singleArticleMode: React.PropTypes.bool,
   componentLoadedInBrowser: React.PropTypes.func
 }
 
 NavigatorAndTutorialView.contextTypes = {
   getStore: React.PropTypes.func,
   executeAction: React.PropTypes.func
+};
+
+NavigatorAndTutorialView.deafultProps = {
+  singleArticleMode: false
 };
 
 NavigatorAndTutorialView = provideContext(connectToStores(NavigatorAndTutorialView, [TutorialStore], (context, props) => {

--- a/src/view/tutorial-view.jsx
+++ b/src/view/tutorial-view.jsx
@@ -12,9 +12,9 @@ import { connectToStores, provideContext } from 'fluxible-addons-react';
 class TutorialView extends React.Component {
 
   renderTitle() {
-    let {platform, article} = this.props;
+    let {platform, article, singleArticleMode} = this.props;
     if (platform && article) {
-      if (platform.articles.length === 1 || article.number === 0) {
+      if (singleArticleMode || platform.articles.length === 1 || article.number === 0) {
         return platform.title + " SDK Tutorial";
       } else {
         return platform.title + " " + article.title;
@@ -24,12 +24,12 @@ class TutorialView extends React.Component {
 
   render() {
 
-    let {quickstart, platform, article} = this.props;
+    let {quickstart, platform, article, singleArticleMode} = this.props;
     let sidebar = null;
     let tutorial = null;
     let columnWidth = 12;
 
-    if (platform && platform.articles.length > 1) {
+    if (!singleArticleMode && platform && platform.articles.length > 1) {
       columnWidth = 9
       sidebar = <div className="col-sm-3">
         <TutorialTableOfContents quickstart={quickstart} platform={platform} currentArticle={article} />


### PR DESCRIPTION
Closes #52.

When the `singleArticleMode` flag is set on `NavigatorAndTutorialView` or `TutorialNavigator`, only a single tutorial will be shown per platform and the `TutorialTableOfContents` will always be hidden.

To see this in action, you can run `npm run dev` and then load `http://localhost:8890?single`.

A related change to the management site will be required to enable this flag.