### PR TITLE
Add support for an article in single-article mode that isn't part of the regular article list

### DIFF
--- a/css/tutorial-navigator.styl
+++ b/css/tutorial-navigator.styl
@@ -17,7 +17,7 @@
   min-height: 525px;
   background: #F3F3F3;
   position: relative;
-  color: color_oil;
+  color: $color-oil;
 
   .container
     min-width: auto;
@@ -25,7 +25,7 @@
 
   .banner
     background: none;
-    color: color_oil;
+    color: $color-oil;
     margin: 0;
     transition: min-height 100ms ease;
     color: #333;
@@ -50,7 +50,7 @@
 
       span
         font-size: 14px;
-        color: color_oil;
+        color: $color-oil;
         display: block;
 
         +breakpoint("desktop")
@@ -77,7 +77,7 @@
     margin: 20px 0;
     margin-bottom: 10px;
     display: inline-block;
-    color: color_oil;
+    color: $color-oil;
     font-size: 20px;
 
   .tenant-switcher
@@ -178,7 +178,7 @@
       transition: opacity 100ms ease;
 
     .description.description
-      color: color_oil;
+      color: $color-oil;
       line-height: normal;
       font-size: 1rem;
       margin-bottom: 10px;
@@ -205,7 +205,7 @@
 
     .symbol
       display: inline-block;
-      background: color_green;
+      background: $color-green;
       border-radius: 50%;
       height: 100px;
       width: 100px;
@@ -234,7 +234,7 @@
   .quickstart:hover
     +breakpoint("desktop")
       background: white;
-      color: color_oil;
+      color: $color-oil;
       box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
 
       .symbol
@@ -268,7 +268,7 @@
     opacity: 0.5;
 
   a
-    color: color_oil;
+    color: $color-oil;
     font-weight: normal
     display: inline-block
     cursor: pointer
@@ -277,7 +277,7 @@
     padding: 0 5px;
 
   .text
-    color: color_oil;
+    color: $color-oil;
     border-radius: 20px;
 
     &:hover
@@ -291,23 +291,55 @@
     padding 0
   .tutorial-toc-title
     font-size 24px
-    color color_text_light
+    color $color-text-light
   .tutorial-toc-description
     font-size 12px
     line-height 18px
-    color color_text_light
+    color $color-text-light
     margin 10px 0 20px
   .tutorial-toc-article
     cursor pointer
     list-style none
     margin-bottom 14px
     font-size 14px
-    color color_text_light
+    color $color-text-light
     &:hover
-      color color_text_gray
+      color $color-text
     &.selected
-      color color_text_gray
+      color $color-text
       font-weight 700
+
+.tutorial-next-steps
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2)
+  padding: 40px 40px 26px 40px
+  margin: 20px 0
+  h2
+    font-size: 24px
+    margin: 0px
+  p
+    margin: 4px 0 28px 0
+    color: $color-text-light
+  .tutorial-next-steps-articles
+    margin: 0
+    padding: 0
+    max-width: 600px
+    li
+      list-style-type: none
+      display: inline-block
+      width: 50%
+      font-weight: 500
+      margin-bottom: 14px
+      a
+        &:link, &:visited
+          color: $color-text
+        &:hover, &:active
+          color: #0a84ae
+      i
+        padding-right: 6px
+
+@media screen and (max-width: 480px)
+  .tutorial-next-steps .tutorial-next-steps-articles li
+    width: 100%
 
 .tutorial-prevnext
   padding: 30px 0 60px
@@ -344,7 +376,7 @@
   .center .quickstart
     cursor: pointer;
     background: white;
-    color: color_oil;
+    color: $color-oil;
     pointer-events: auto;
     opacity: 1;
 

--- a/example/src/example.js
+++ b/example/src/example.js
@@ -12,6 +12,11 @@ var EXAMPLE_QUICKSTART_DATA = {
         "name": "native-multi-example",
         "title": "Native Multi-Step Platform",
         "image": "/media/platforms/react.png",
+        "defaultArticle": {
+          "name": "native-multi-example-summary",
+          "title": "Summary",
+          "url": "//articles/x-native-platforms/native-multi-example/summary"
+        },
         "articles": [
           {
             "name": "login",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "description": "Auth0's quickstarts",
   "dependencies": {
-    "auth0-styleguide": "auth0/styleguide#2.2.7",
+    "auth0-styleguide": "auth0/styleguide#4.8.6",
     "flux": ">=2.1.1",
     "fluxible-addons-react": "^0.2.8",
     "fluxible-plugin-service-proxy": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-tutorial-navigator",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "private": true,
   "main": "index.js",
   "description": "Auth0's quickstarts",

--- a/src/action/load-article-action.js
+++ b/src/action/load-article-action.js
@@ -14,7 +14,7 @@ export default function loadArticleAction(context, payload, done) {
   if (quickstartId && platformId && !articleId) {
     let platform = quickstarts[quickstartId].platforms[platformId];
     if (isSingleArticleMode && platform.defaultArticle) {
-      articleId = platform.defaultArticle;
+      articleId = platform.defaultArticle.name;
     }
     else {
       articleId = platform.articles[0].name;

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import navigateAction from './action/navigate-action';
 import Breadcrumbs from './components/breadcrumbs';
 import Tutorial from './components/tutorial';
 import TutorialNavigator from './components/tutorial-navigator';
+import TutorialNextSteps from './components/tutorial-next-steps';
 import TutorialTableOfContents from './components/tutorial-table-of-contents';
 import TutorialPrevNext from './components/tutorial-prev-next';
 import ArticleService from './services/article-service';
@@ -21,6 +22,7 @@ module.exports = {
   NavigatorAndTutorialView,
   Tutorial,
   TutorialNavigator,
+  TutorialNextSteps,
   TutorialTableOfContents,
   TutorialPrevNext,
 

--- a/src/components/tutorial-next-steps.jsx
+++ b/src/components/tutorial-next-steps.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import _ from 'lodash';
+
+const BASE_URL = "https://auth0.com/docs/quickstart";
+const DEFAULT_ARTICLE_BUDICON = 691;
+
+class TutorialNextSteps extends React.Component {
+
+  render() {
+
+    let {quickstart, platform} = this.props;
+
+    let items = platform.articles.map((article, index) => {
+      let icon = article.budicon ? article.budicon : DEFAULT_ARTICLE_BUDICON;
+      let href = [BASE_URL, quickstart.name, platform.name, article.name].join('/');
+      return (
+        <li key={index} className="tutorial-next-steps-article">
+          <a href={href} target="_blank">
+            <i className={"icon icon-budicon-" + icon } />
+            {article.title}
+          </a>
+        </li>
+      );
+    });
+
+    return (
+      <div className="tutorial-next-steps">
+        <h2>What can you do next?</h2>
+        <p>Check our tutorials to learn more about using Auth0 in your {platform.title} apps.</p>
+        <ul className="tutorial-next-steps-articles">
+          {items}
+        </ul>
+      </div>
+    );
+
+  }
+
+}
+
+TutorialNextSteps.propTypes = {
+  quickstart: React.PropTypes.object,
+  platform: React.PropTypes.object
+}
+
+export default TutorialNextSteps;

--- a/src/stores/tutorial-store.js
+++ b/src/stores/tutorial-store.js
@@ -47,11 +47,11 @@ class TutorialStore extends BaseStore {
   getCurrentArticle() {
     let platform = this.getCurrentPlatform();
     if (platform) {
-      if (this.currentArticleId) {
-        return _.find(platform.articles, {name: this.currentArticleId});
+      if (this.singleArticleMode && platform.defaultArticle) {
+        return platform.defaultArticle;
       }
-      else if (this.singleArticleMode && platform.defaultArticle) {
-        return _.find(platform.articles, {name: platform.defaultArticle});
+      else if (this.currentArticleId) {
+        return _.find(platform.articles, {name: this.currentArticleId});
       }
       else {
         return _.first(platform.articles);

--- a/src/view/tutorial-view.jsx
+++ b/src/view/tutorial-view.jsx
@@ -4,6 +4,7 @@ import ArticleStore from '../stores/article-store';
 import Breadcrumbs from '../components/breadcrumbs';
 import Tutorial from '../components/tutorial';
 import TutorialTableOfContents from '../components/tutorial-table-of-contents';
+import TutorialNextSteps from '../components/tutorial-next-steps';
 import { connectToStores, provideContext } from 'fluxible-addons-react';
 
 // TODO: There's a lot of duplication here vs. the TutorialPage component in auth0-docs.
@@ -27,6 +28,7 @@ class TutorialView extends React.Component {
     let {quickstart, platform, article, isSingleArticleMode} = this.props;
     let sidebar = null;
     let tutorial = null;
+    let nextSteps = null;
     let columnWidth = 12;
 
     if (!isSingleArticleMode && platform && platform.articles.length > 1) {
@@ -34,6 +36,10 @@ class TutorialView extends React.Component {
       sidebar = <div className="col-sm-3">
         <TutorialTableOfContents quickstart={quickstart} platform={platform} currentArticle={article} />
       </div>;
+    }
+
+    if (isSingleArticleMode) {
+      nextSteps = <TutorialNextSteps quickstart={quickstart} platform={platform} />;
     }
 
     return (
@@ -48,6 +54,7 @@ class TutorialView extends React.Component {
               <section className="docs-content">
                 <h1 className="tutorial-title">{this.renderTitle()}</h1>
                 <Tutorial {...this.props} />
+                {nextSteps}
               </section>
               <div id="try-banner">
                 <div className="try-banner try-banner-alt">


### PR DESCRIPTION
In conjunction with https://github.com/auth0/auth0-docs/pull/1118, closes https://github.com/auth0/auth0-docs/issues/1105.

This enhances the "default article" that can be defined on a platform. Previously, the default article was just a reference to one of the articles in the regular article list. After this patch, the default article can (optionally) be a standalone article that doesn't show up in the article list. If no default article is specified for a platform, the first article is used instead.

When the tutorial navigator is in single-article mode, the default article is shown for the platform and the table of contents is hidden. Instead, a `TutorialNextSteps` component is added to the end of the tutorial article, containing the same TOC content in a different visual form. The links within the "next steps" banner are opened in a new window, and are hard-coded to the production docs site.