### PR TITLE
Fix quickstart default styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [3.9.1] - 2016-10-05
+
+### Fixed
+
+- [] Don't show center state of quickstart list in desktop view. (`Ariel Gerstein`)
+  https://github.com/auth0/tutorial-navigator/commit/d8b3383610cb865ffb0101bba1c2897f481acaac
+- [] Hide quickstart list when slider is not initialized. (`Ariel Gerstein`)
+  https://github.com/auth0/tutorial-navigator/commit/7a10cfba92262390d4e1f56254bf9b8e05d84d76
+- [] Show disabled quick start style only if carousel is loaded. (`Ariel Gerstein`)
+  https://github.com/auth0/tutorial-navigator/commit/7e02f8fb8b1bf0b468622a39c9a3c4443ef43668
+- [] Don't hide quickstarts when slider is not initialized. (`Ariel Gerstein`)
+  https://github.com/auth0/tutorial-navigator/commit/13689e5f578cdab77794fe10144172e6a64a1970
+- [] Revert styles from last commit. (`Ariel Gerstein`)
+  https://github.com/auth0/tutorial-navigator/commit/f361f0700d42a95af96a7d5f9ed7448a6c5b996a
+
 ## [3.8.0] - 2016-09-27
 
 ### Fixed

--- a/css/carousel.styl
+++ b/css/carousel.styl
@@ -19,7 +19,7 @@
 .js-carousel
   position relative
   z-index 1
-  // display none
+  display none
   width 100%
   -webkit-tap-highlight-color transparent
 

--- a/css/carousel.styl
+++ b/css/carousel.styl
@@ -19,7 +19,7 @@
 .js-carousel
   position relative
   z-index 1
-  display none
+  // display none
   width 100%
   -webkit-tap-highlight-color transparent
 

--- a/css/quickstarts.styl
+++ b/css/quickstarts.styl
@@ -18,22 +18,23 @@
   .js-carousel.owl-loaded
 
     .center .quickstart
-      cursor: pointer;
-      background: white;
-      color: $color-oil;
-      pointer-events: auto;
-      opacity: 1;
-
-      .cta
-        opacity: 1;
+      +breakpoint("tablet", "max")
+        cursor: pointer;
+        background: white;
+        color: $color-oil;
         pointer-events: auto;
-
-      i,
-      .symbol
         opacity: 1;
 
-      .symbol
-        background: #F3F3F3;
+        .cta
+          opacity: 1;
+          pointer-events: auto;
+
+        i,
+        .symbol
+          opacity: 1;
+
+        .symbol
+          background: #F3F3F3;
 
     .quickstart
       +breakpoint("tablet", "max")

--- a/css/quickstarts.styl
+++ b/css/quickstarts.styl
@@ -5,7 +5,7 @@
     padding-top: 30px;
     margin: 0 auto;
 
-  +breakpoint("desktop")
+  +breakpoint("tablet")
     min-height: 302px;
 
   .item
@@ -13,6 +13,42 @@
 
 
 #tutorial-navigator
+
+  // Carousel loaded quickstart styles
+  .js-carousel.owl-loaded
+
+    .center .quickstart
+      cursor: pointer;
+      background: white;
+      color: $color-oil;
+      pointer-events: auto;
+      opacity: 1;
+
+      .cta
+        opacity: 1;
+        pointer-events: auto;
+
+      i,
+      .symbol
+        opacity: 1;
+
+      .symbol
+        background: #F3F3F3;
+
+    .quickstart
+      +breakpoint("tablet", "max")
+        opacity: 0.3;
+        background: #A9B3BC;
+        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+        pointer-events: none;
+
+        .symbol
+          opacity: 0.5;
+
+        .cta
+          opacity: 1;
+          pointer-events: none;
+
 
   .quickstart
     white-space normal
@@ -25,18 +61,17 @@
     animation-timing-function cubic-bezier(0.455, 0.03, 0.515, 0.955)
     animation-duration 200ms
 
+    // Default styles when carousel is not loaded
     +breakpoint("tablet", "max")
-      opacity: 0.3;
-      background: #A9B3BC;
       box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-      pointer-events: none;
+      background-color white
+      color $color-oil
 
       .symbol
-        opacity: 0.5;
+        background-color #F3F3F3
 
       .cta
         opacity: 1;
-        pointer-events: none;
 
     .symbol
       display inline-block;
@@ -132,21 +167,3 @@
 
         .cta
           opacity: 1;
-
-  .center .quickstart
-    cursor: pointer;
-    background: white;
-    color: $color-oil;
-    pointer-events: auto;
-    opacity: 1;
-
-    .cta
-      opacity: 1;
-      pointer-events: auto;
-
-    i,
-    .symbol
-      opacity: 1;
-
-    .symbol
-      background: #F3F3F3;

--- a/css/tutorial-navigator.styl
+++ b/css/tutorial-navigator.styl
@@ -153,132 +153,6 @@
     +breakpoint("tablet")
       font-size: 13px;
 
-  .quickstart
-    cursor: pointer;
-    padding: 15px 10px;
-    border-radius: 3px;
-    transition: background 100ms ease;
-    margin-bottom: 5px;
-    animation-timing-function: cubic-bezier(0.455, 0.03, 0.515, 0.955);
-    animation-duration: 200ms;
-
-    .btn
-      letter-spacing: 0.005em;
-      font-size: 12px;
-
-    .title
-      display: block;
-      color: #333;
-
-    .cta
-      opacity: 0;
-      transition: opacity 100ms ease;
-
-    .description.description
-      color: $color-oil;
-      line-height: normal;
-      font-size: 1rem;
-      margin-bottom: 10px;
-      max-width: 180px;
-
-    .sample
-      opacity: 0.5;
-      font-size: 12px;
-
-    &[data-type="native"]
-      .symbol
-        &:after
-          background-image: url('https://auth0.com/docs/img/quickstarts/native-mobile.svg');
-
-    &[data-type="web"]
-      .symbol
-        &:after
-          background-image: url('https://auth0.com/docs/img/quickstarts/spa.svg');
-
-    &[data-type="service"]
-      .symbol
-        &:after
-          background-image: url('https://auth0.com/docs/img/quickstarts/backend.svg');
-
-    .symbol
-      display: inline-block;
-      background: $color-green;
-      border-radius: 50%;
-      height: 100px;
-      width: 100px;
-      margin-bottom: 20px;
-      background: white;
-      position: relative;
-
-      &:after
-        position: absolute;
-        top: 0;
-        left: 0;
-        content: "";
-        display: block;
-        height: 100%;
-        width: 100%;
-        background-size: 50% 50%;
-        background-repeat: no-repeat;
-        background-position: center center;
-
-      i
-        font-size: 40px;
-        top: 30%;
-        animation: none;
-        color: #363C42;
-
-  .quickstart:hover
-    +breakpoint("desktop")
-      background: white;
-      color: $color-oil;
-      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-
-      .symbol
-        background: #F3F3F3;
-
-      .cta
-        opacity: 1;
-
-.breadcrumbs
-  font-size: 12px;
-  margin: 15px 10px;
-  padding: 3px 15px;
-  line-height: 2.5;
-  background: white;
-  border-radius: 3px;
-  display: inline-block;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
-  cursor: pointer;
-
-  > div
-    display: inline-block;
-
-  i
-    font-size: 12px;
-    animation: none;
-    margin: 0;
-    position: relative;
-    top: 3px;
-    margin-left: 12px;
-    margin-right: 10px;
-    opacity: 0.5;
-
-  a
-    color: $color-oil;
-    font-weight: normal
-    display: inline-block
-    cursor: pointer
-
-  .plus
-    padding: 0 5px;
-
-  .text
-    color: $color-oil;
-    border-radius: 20px;
-
-    &:hover
-      opacity: 1;
 
 .tutorial-toc
   margin-top 20px
@@ -323,6 +197,7 @@
     li
       list-style-type: none
       display: inline-block
+      font-weight 500
       width: 50%
       margin-bottom: 14px
       a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-tutorial-navigator",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": true,
   "main": "index.js",
   "description": "Auth0's quickstarts",


### PR DESCRIPTION
Fix default styles of quickstart list so you can click on the quickstarts even if the carousel is not initialized (what happens in manage site when you enter to the quickstart with a application of "No type").

Right now if you go to Manage site in tablet viewport with an application of "No type" you can't click on the quickstarts:

![image](https://cloud.githubusercontent.com/assets/6318057/19284218/5b4eb562-8fcb-11e6-9371-3a36243d3480.png)

This should fix this error also:
https://github.com/auth0/manage/pull/2382#issuecomment-251765374